### PR TITLE
[SOL] Strip full paths from source filenames referred in messages

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -24,6 +24,8 @@ use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode};
 use rustc_target::abi::{self, LayoutOf};
 use rustc_target::spec::abi::Abi;
 
+use std::path::{Path, PathBuf};
+
 /// Used by `FunctionCx::codegen_terminator` for emitting common patterns
 /// e.g., creating a basic block, calling a function, etc.
 struct TerminatorCodegenHelper<'tcx> {
@@ -1147,8 +1149,28 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let mut span_to_caller_location = |span: Span| {
             let topmost = span.ctxt().outer_expn().expansion_cause().unwrap_or(span);
             let caller = tcx.sess.source_map().lookup_char_pos(topmost.lo());
+            let file_name = if tcx.sess.target.arch == "bpf" {
+                let file_name = caller.file.name.to_string();
+                let mut path = Path::new(&file_name);
+                let components = path.components().collect::<Vec<_>>();
+                let len = components.len();
+                let mut buf = PathBuf::new();
+                if len > 3 {
+                    buf.push(components[len - 3].as_os_str());
+                    buf.push(components[len - 2].as_os_str());
+                    buf.push(components[len - 1].as_os_str());
+                    path = buf.as_path();
+                }
+                if let Some(path_str) = path.to_str() {
+                    Symbol::intern(&path_str)
+                } else {
+                    Symbol::intern(&file_name)
+                }
+            } else {
+                Symbol::intern(&caller.file.name.to_string())
+            };
             let const_loc = tcx.const_caller_location((
-                Symbol::intern(&caller.file.name.to_string()),
+                file_name,
                 caller.line as u32,
                 caller.col_display as u32 + 1,
             ));


### PR DESCRIPTION
Prevent including users local paths in generated binary files.