### PR TITLE
Add support for windows in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,13 +7,15 @@ if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
     exit;
 fi
 
-if [ "$(uname)" == "Darwin" ]; then
-    HOST_TRIPLE=x86_64-apple-darwin
-else
-    HOST_TRIPLE=x86_64-unknown-linux-gnu
-fi
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     HOST_TRIPLE=x86_64-unknown-linux-gnu;;
+    Darwin*)    HOST_TRIPLE=x86_64-apple-darwin;;
+    MINGW*)     HOST_TRIPLE=x86_64-pc-windows-msvc;;
+    *)          HOST_TRIPLE=x86_64-unknown-linux-gnu
+esac
 
 if [ "$1" == "--llvm" ]; then
-    rm -f build/x86_64-apple-darwin/llvm/llvm-finished-building;
+    rm -f build/${HOST_TRIPLE}/llvm/llvm-finished-building;
 fi
 ./x.py build --stage 1 --target ${HOST_TRIPLE},bpfel-unknown-unknown


### PR DESCRIPTION
#### Problem

In order to support `cargo build-bpf` on Windows, we first have to build llvm / rust for windows.

#### Solution

This one's pretty easy -- we just have to add the new triple for windows.

Side note: please let me know if I should also put in a PR to make this change against master.