### PR TITLE
Enable native build on apple silicon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,12 +7,13 @@ if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
     exit;
 fi
 
-unameOut="$(uname -s)"
+unameOut="$(uname -s)-$(uname -m)"
 case "${unameOut}" in
-    Linux*)     HOST_TRIPLE=x86_64-unknown-linux-gnu;;
-    Darwin*)    HOST_TRIPLE=x86_64-apple-darwin;;
-    MINGW*)     HOST_TRIPLE=x86_64-pc-windows-msvc;;
-    *)          HOST_TRIPLE=x86_64-unknown-linux-gnu
+    Linux*)         HOST_TRIPLE=x86_64-unknown-linux-gnu;;
+    Darwin-x86_64*) HOST_TRIPLE=x86_64-apple-darwin;;
+    Darwin-arm64*)  HOST_TRIPLE=aarch64-apple-darwin;;
+    MINGW*)         HOST_TRIPLE=x86_64-pc-windows-msvc;;
+    *)              HOST_TRIPLE=x86_64-unknown-linux-gnu
 esac
 
 if [ "$1" == "--llvm" ]; then

--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,7 @@ assertions = false
 # likely, teach rustc about the C ABI of the target. Get in touch with the
 # Rust team and file an issue if you need assistance in porting!
 #targets = "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86"
-targets = "X86"
+targets = "AArch64;X86"
 
 # LLVM experimental targets to build support for. These targets are specified in
 # the same format as above, but since these targets are experimental, they are


### PR DESCRIPTION
Allows `./build.sh` to work natively on Apple Silicon (M1). Prerequisite to update the bpf-tools.