### PR TITLE
Link using rust-lld

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -390,7 +390,7 @@ debug-assertions = false
 
 # Indicates whether LLD will be compiled and made available in the sysroot for
 # rustc to execute.
-#lld = false
+lld = true
 
 # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
 # sysroot.


### PR DESCRIPTION
This PR changes bpfel-u-u to link using rust-lld instead of manually looking up ld.lld in the llvm dist folder. rust-lld is guaranteed to be in the rustc sysroot when rust.lld = true in config.toml. This simplifies the code and makes linking work in CI, where we don't have bpf-tools installed.

Marking as draft since it requires changes to bpf-tools which I'm going to submit next.