### PR TITLE
CI: run tests on push and improve run times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
     name: PR
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
-      SCCACHE_BUCKET: rust-lang-ci-sccache2
+      SCCACHE_BUCKET: cached-ci-artifacts
+      SCCACHE_REGION: us-east-2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
-      CACHE_DOMAIN: ci-caches.rust-lang.org
+      CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
     if: "github.event_name == 'pull_request'"
     strategy:
       matrix:
@@ -49,10 +50,6 @@ jobs:
           - name: bpfel-unknown-unknown
             os: ubuntu-latest
             env: {}
-          - name: x86_64-gnu-tools
-            env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            os: ubuntu-latest
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:
@@ -143,19 +140,139 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: "${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
+          SKIP_JOB: 1
+        if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
+  push:
+    name: push
+    env:
+      CI_JOB_NAME: "${{ matrix.name }}"
+      SCCACHE_BUCKET: cached-ci-artifacts
+      SCCACHE_REGION: us-east-2
+      DEPLOY_BUCKET: rust-lang-ci2
+      TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
+      TOOLSTATE_ISSUES_API_URL: "https://api.github.com/repos/rust-lang/rust/issues"
+      TOOLSTATE_PUBLISH: 0
+      CACHES_AWS_ACCESS_KEY_ID: AKIASSXOBJJGY5HRQO4U
+      ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZN24CBO55
+      CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'solana-labs/rust'"
+    strategy:
+      matrix:
+        include:
+          - name: mingw-check
+            os: ubuntu-latest
+            env: {}
+          - name: x86_64-gnu-llvm-10
+            os: ubuntu-latest
+            env: {}
+          - name: bpfel-unknown-unknown
+            os: ubuntu-latest
+            env: {}
+    timeout-minutes: 600
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: disable git crlf conversion
+        run: git config --global core.autocrlf false
+      - name: checkout the source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: configure the PR in which the error message will be posted
+        run: "echo \"[CI_PR_NUMBER=$num]\""
+        env:
+          num: "${{ github.event.number }}"
+        if: "success() && !env.SKIP_JOB && github.event_name == 'pull_request'"
+      - name: add extra environment variables
+        run: src/ci/scripts/setup-environment.sh
+        env:
+          EXTRA_VARIABLES: "${{ toJson(matrix.env) }}"
+        if: success() && !env.SKIP_JOB
+      - name: decide whether to skip this job
+        run: src/ci/scripts/should-skip-this.sh
+        if: success() && !env.SKIP_JOB
+      - name: configure GitHub Actions to kill the build when outdated
+        uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
+        if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
+      - name: collect CPU statistics
+        run: src/ci/scripts/collect-cpu-stats.sh
+        if: success() && !env.SKIP_JOB
+      - name: show the current environment
+        run: src/ci/scripts/dump-environment.sh
+        if: success() && !env.SKIP_JOB
+      - name: install awscli
+        run: src/ci/scripts/install-awscli.sh
+        if: success() && !env.SKIP_JOB
+      - name: install sccache
+        run: src/ci/scripts/install-sccache.sh
+        if: success() && !env.SKIP_JOB
+      - name: select Xcode
+        run: src/ci/scripts/select-xcode.sh
+        if: success() && !env.SKIP_JOB
+      - name: install clang
+        run: src/ci/scripts/install-clang.sh
+        if: success() && !env.SKIP_JOB
+      - name: install WIX
+        run: src/ci/scripts/install-wix.sh
+        if: success() && !env.SKIP_JOB
+      - name: ensure the build happens on a partition with enough space
+        run: src/ci/scripts/symlink-build-dir.sh
+        if: success() && !env.SKIP_JOB
+      - name: disable git crlf conversion
+        run: src/ci/scripts/disable-git-crlf-conversion.sh
+        if: success() && !env.SKIP_JOB
+      - name: install MSYS2
+        run: src/ci/scripts/install-msys2.sh
+        if: success() && !env.SKIP_JOB
+      - name: install MinGW
+        run: src/ci/scripts/install-mingw.sh
+        if: success() && !env.SKIP_JOB
+      - name: install ninja
+        run: src/ci/scripts/install-ninja.sh
+        if: success() && !env.SKIP_JOB
+      - name: enable ipv6 on Docker
+        run: src/ci/scripts/enable-docker-ipv6.sh
+        if: success() && !env.SKIP_JOB
+      - name: disable git crlf conversion
+        run: src/ci/scripts/disable-git-crlf-conversion.sh
+        if: success() && !env.SKIP_JOB
+      - name: checkout submodules
+        run: src/ci/scripts/checkout-submodules.sh
+        if: success() && !env.SKIP_JOB
+      - name: ensure line endings are correct
+        run: src/ci/scripts/verify-line-endings.sh
+        if: success() && !env.SKIP_JOB
+      - name: ensure backported commits are in upstream branches
+        run: src/ci/scripts/verify-backported-commits.sh
+        if: success() && !env.SKIP_JOB
+      - name: run the build
+        run: src/ci/scripts/run-build-from-ci.sh
+        env:
+          AWS_ACCESS_KEY_ID: "${{ env.CACHES_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}"
+          TOOLSTATE_REPO_ACCESS_TOKEN: "${{ secrets.TOOLSTATE_REPO_ACCESS_TOKEN }}"
+        if: success() && !env.SKIP_JOB
+      - name: upload artifacts to S3
+        run: src/ci/scripts/upload-artifacts.sh
+        env:
+          AWS_ACCESS_KEY_ID: "${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
+          SKIP_JOB: 1
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   auto:
     name: auto
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
-      SCCACHE_BUCKET: rust-lang-ci-sccache2
+      SCCACHE_BUCKET: cached-ci-artifacts
+      SCCACHE_REGION: us-east-2
       DEPLOY_BUCKET: rust-lang-ci2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       TOOLSTATE_ISSUES_API_URL: "https://api.github.com/repos/rust-lang/rust/issues"
-      TOOLSTATE_PUBLISH: 1
-      CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZI5DHEBFL
+      TOOLSTATE_PUBLISH: 0
+      CACHES_AWS_ACCESS_KEY_ID: AKIASSXOBJJGY5HRQO4U
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZN24CBO55
-      CACHE_DOMAIN: ci-caches.rust-lang.org
+      CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
     if: "github.event_name == 'push' && github.ref == 'refs/heads/auto' && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -515,19 +632,21 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: "${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
+          SKIP_JOB: 1
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   try:
     name: try
     env:
       CI_JOB_NAME: "${{ matrix.name }}"
-      SCCACHE_BUCKET: rust-lang-ci-sccache2
+      SCCACHE_BUCKET: cached-ci-artifacts
+      SCCACHE_REGION: us-east-2
       DEPLOY_BUCKET: rust-lang-ci2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       TOOLSTATE_ISSUES_API_URL: "https://api.github.com/repos/rust-lang/rust/issues"
-      TOOLSTATE_PUBLISH: 1
-      CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZI5DHEBFL
+      TOOLSTATE_PUBLISH: 0
+      CACHES_AWS_ACCESS_KEY_ID: AKIASSXOBJJGY5HRQO4U
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZN24CBO55
-      CACHE_DOMAIN: ci-caches.rust-lang.org
+      CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
     if: "github.event_name == 'push' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/try-perf') && github.repository == 'rust-lang-ci/rust'"
     strategy:
       matrix:
@@ -625,19 +744,21 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: "${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}"
+          SKIP_JOB: 1
         if: "success() && !env.SKIP_JOB && (github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1')"
   master:
     name: master
     runs-on: ubuntu-latest
     env:
-      SCCACHE_BUCKET: rust-lang-ci-sccache2
+      SCCACHE_BUCKET: cached-ci-artifacts
+      SCCACHE_REGION: us-east-2
       DEPLOY_BUCKET: rust-lang-ci2
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       TOOLSTATE_ISSUES_API_URL: "https://api.github.com/repos/rust-lang/rust/issues"
-      TOOLSTATE_PUBLISH: 1
-      CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZI5DHEBFL
+      TOOLSTATE_PUBLISH: 0
+      CACHES_AWS_ACCESS_KEY_ID: AKIASSXOBJJGY5HRQO4U
       ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZN24CBO55
-      CACHE_DOMAIN: ci-caches.rust-lang.org
+      CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
     if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'rust-lang-ci/rust'"
     steps:
       - name: checkout the source code

--- a/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
+++ b/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
@@ -22,6 +22,7 @@ RUN git clone https://github.com/solana-labs/cargo-run-bpf-tests
 WORKDIR /cargo-run-bpf-tests
 RUN cargo build
 RUN cp target/debug/cargo-run-bpf-tests /usr/local/bin
+RUN rm -rf target
 WORKDIR /
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -6,7 +6,7 @@ set -ex
 
 case "$(uname -m)" in
     x86_64)
-        url="https://ci-mirrors.rust-lang.org/rustc/2021-08-24-sccache-v0.2.15-x86_64-unknown-linux-musl"
+        url="https://cached-ci-artifacts.s3.us-east-2.amazonaws.com/sccache-bc014e0-x86_64-unknown-linux-musl"
         ;;
     aarch64)
         url="https://ci-mirrors.rust-lang.org/rustc/2021-08-25-sccache-v0.2.15-aarch64-unknown-linux-musl"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -33,24 +33,26 @@ x--expand-yaml-anchors--remove:
     CI_JOB_NAME: ${{ matrix.name }}
 
   - &public-variables
-    SCCACHE_BUCKET: rust-lang-ci-sccache2
+    SCCACHE_BUCKET: cached-ci-artifacts
+    SCCACHE_REGION: us-east-2
     TOOLSTATE_REPO: https://github.com/rust-lang-nursery/rust-toolstate
-    CACHE_DOMAIN: ci-caches.rust-lang.org
+    CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
 
   - &prod-variables
-    SCCACHE_BUCKET: rust-lang-ci-sccache2
+    SCCACHE_BUCKET: cached-ci-artifacts
+    SCCACHE_REGION: us-east-2
     DEPLOY_BUCKET: rust-lang-ci2
     TOOLSTATE_REPO: https://github.com/rust-lang-nursery/rust-toolstate
     TOOLSTATE_ISSUES_API_URL: https://api.github.com/repos/rust-lang/rust/issues
-    TOOLSTATE_PUBLISH: 1
+    TOOLSTATE_PUBLISH: 0
     # AWS_SECRET_ACCESS_KEYs are stored in GitHub's secrets storage, named
     # AWS_SECRET_ACCESS_KEY_<keyid>. Including the key id in the name allows to
     # rotate them in a single branch while keeping the old key in another
     # branch, which wouldn't be possible if the key was named with the kind
     # (caches, artifacts...).
-    CACHES_AWS_ACCESS_KEY_ID: AKIA46X5W6CZI5DHEBFL
+    CACHES_AWS_ACCESS_KEY_ID: AKIASSXOBJJGY5HRQO4U
     ARTIFACTS_AWS_ACCESS_KEY_ID: AKIA46X5W6CZN24CBO55
-    CACHE_DOMAIN: ci-caches.rust-lang.org
+    CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
 
   - &dummy-variables
     SCCACHE_BUCKET: rust-lang-gha-caches
@@ -221,6 +223,7 @@ x--expand-yaml-anchors--remove:
         env:
           AWS_ACCESS_KEY_ID: ${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}
+          SKIP_JOB: 1
         # Adding a condition on DEPLOY=1 or DEPLOY_ALT=1 is not needed as all deploy
         # builders *should* have the AWS credentials available. Still, explicitly
         # adding the condition is helpful as this way CI will not silently skip
@@ -292,9 +295,22 @@ jobs:
           - name: bpfel-unknown-unknown
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-tools
-            env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
+  push:
+    <<: *base-ci-job
+    name: push
+    env:
+      <<: [*shared-ci-variables, *prod-variables]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'solana-labs/rust'
+    strategy:
+      matrix:
+        include:
+          - name: mingw-check
+            <<: *job-linux-xl
+
+          - name: x86_64-gnu-llvm-10
+            <<: *job-linux-xl
+
+          - name: bpfel-unknown-unknown
             <<: *job-linux-xl
 
   auto:


### PR DESCRIPTION
Run tests on push to master in addition to running them on pull requests and setup S3 caching to improve run times.

Docker images for for the jobs are cached in s3://cached-ci-artifacts/docker and LLVM/lld build artifacts are cached through sccache.

A custom sccache fork is used. The custom fork is needed to workaround https://github.com/mozilla/sccache/issues/633 happening with our S3 bucket, which only supports the v4 signature scheme.

This brings the run time for the bpfel-unknown-unknown job from nearly 4 hours to less than an hour. 🎉 Another ~25m or so can be cut from each job by compiling stage0 with sccache (right now only LLVM and lld get compiled with it), which is something I'm planning to do at some point soon.