### PR TITLE
Enable all core tests (except atomics)

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -2,7 +2,6 @@
 
 use crate::fmt;
 use crate::mem::MaybeUninit;
-#[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
 use crate::num::fmt as numfmt;
 use crate::ops::{Div, Rem, Sub};
 use crate::ptr;
@@ -291,7 +290,6 @@ macro_rules! impl_Display {
     };
 }
 
-#[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
 macro_rules! impl_Exp {
     ($($t:ident),* as $u:ident via $conv_fn:ident named $name:ident) => {
         fn $name(
@@ -466,7 +464,6 @@ mod imp {
             as u64 via to_u64 named fmt_u64
     );
 
-    #[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
     impl_Exp!(
         i8, u8, i16, u16, i32, u32, i64, u64, usize, isize
             as u64 via to_u64 named exp_u64
@@ -482,7 +479,6 @@ mod imp {
     impl_Exp!(i64, u64 as u64 via to_u64 named exp_u64);
 }
 
-#[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
 impl_Exp!(i128, u128 as u128 via to_u128 named exp_u128);
 
 /// Helper function for writing a u64 into `buf` going from last to first, with `curr`.

--- a/library/core/tests/lazy.rs
+++ b/library/core/tests/lazy.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use core::{
     cell::Cell,
     lazy::{Lazy, OnceCell},
@@ -24,6 +25,8 @@ fn once_cell_get_mut() {
     assert_eq!(c.get_mut(), Some(&mut 92));
 }
 
+// sbf doesn't have mutable static data
+#[cfg(not(any(target_arch = "bpf", target_arg = "sbf")))]
 #[test]
 fn once_cell_drop() {
     static DROP_CNT: AtomicUsize = AtomicUsize::new(0);

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -87,28 +87,22 @@ mod char;
 mod clone;
 mod cmp;
 mod const_ptr;
-#[cfg(not(target_arch = "bpf"))]
 mod fmt;
-#[cfg(not(target_arch = "bpf"))]
 mod hash;
 mod intrinsics;
 mod iter;
-#[cfg(not(target_arch = "bpf"))]
 mod lazy;
 mod macros;
 mod manually_drop;
 mod mem;
 mod nonzero;
-#[cfg(not(target_arch = "bpf"))]
 mod num;
 mod ops;
 mod option;
 mod pattern;
 mod pin;
-#[cfg(not(target_arch = "bpf"))]
 mod ptr;
 mod result;
-#[cfg(not(target_arch = "bpf"))]
 mod slice;
 mod str;
 mod str_lossy;

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -30,6 +30,8 @@ mod bignum;
 
 mod const_from;
 mod dec2flt;
+// sbf doesn't support floats
+#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 mod flt2dec;
 mod int_log;
 mod ops;

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use core::cell::RefCell;
 use core::ptr;
 use core::ptr::*;
@@ -277,6 +278,8 @@ pub fn test_variadic_fnptr() {
     assert_eq!(p.hash(&mut s), q.hash(&mut s));
 }
 
+// sbf doesn't support thread locals
+#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 #[test]
 fn write_unaligned_drop() {
     thread_local! {

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1564,31 +1564,31 @@ fn test_iter_folds() {
 #[test]
 fn test_rotate_left() {
     const N: usize = 600;
-    let a: &mut [_] = &mut [0; N];
+    let a: &mut [_] = &mut [0u8; N];
     for i in 0..N {
-        a[i] = i;
+        a[i] = i as u8;
     }
 
     a.rotate_left(42);
     let k = N - 42;
 
     for i in 0..N {
-        assert_eq!(a[(i + k) % N], i);
+        assert_eq!(a[(i + k) % N], i as u8);
     }
 }
 
 #[test]
 fn test_rotate_right() {
     const N: usize = 600;
-    let a: &mut [_] = &mut [0; N];
+    let a: &mut [_] = &mut [0u8; N];
     for i in 0..N {
-        a[i] = i;
+        a[i] = i as u8;
     }
 
     a.rotate_right(42);
 
     for i in 0..N {
-        assert_eq!(a[(i + 42) % N], i);
+        assert_eq!(a[(i + 42) % N], i as u8);
     }
 }
 
@@ -1638,12 +1638,12 @@ fn sort_unstable() {
     use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
     // Miri is too slow (but still need to `chain` to make the types match)
-    let lens = if cfg!(miri) { (2..20).chain(0..0) } else { (2..25).chain(500..510) };
+    let lens = if cfg!(miri) { (2..20).chain(0..0) } else { (2..25).chain(200..210) };
     let rounds = if cfg!(miri) { 1 } else { 100 };
 
-    let mut v = [0; 600];
-    let mut tmp = [0; 600];
-    let mut rng = StdRng::from_entropy();
+    let mut v = [0; 300];
+    let mut tmp = [0; 300];
+    let mut rng = StdRng::seed_from_u64(0);
 
     for len in lens {
         let v = &mut v[0..len];
@@ -1713,9 +1713,9 @@ fn select_nth_unstable() {
     use rand::seq::SliceRandom;
     use rand::{Rng, SeedableRng};
 
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::seed_from_u64(0);
 
-    for len in (2..21).chain(500..501) {
+    for len in (2..21).chain(200..201) {
         let mut orig = vec![0; len];
 
         for &modulus in &[5, 10, 1000] {

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2893,26 +2893,31 @@ impl RandomState {
     // rand
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     pub fn new() -> RandomState {
-        // Historically this function did not cache keys from the OS and instead
-        // simply always called `rand::thread_rng().gen()` twice. In #31356 it
-        // was discovered, however, that because we re-seed the thread-local RNG
-        // from the OS periodically that this can cause excessive slowdown when
-        // many hash maps are created on a thread. To solve this performance
-        // trap we cache the first set of randomly generated keys per-thread.
-        //
-        // Later in #36481 it was discovered that exposing a deterministic
-        // iteration order allows a form of DOS attack. To counter that we
-        // increment one of the seeds on every RandomState creation, giving
-        // every corresponding HashMap a different iteration order.
-        thread_local!(static KEYS: Cell<(u64, u64)> = {
-            Cell::new(sys::hashmap_random_keys())
-        });
+        if cfg!(any(target_arch = "bpf", target_arch = "sbf")) {
+            // sbf doesn't support thread_local!()
+            RandomState { k0: 0, k1: 0 }
+        } else {
+            // Historically this function did not cache keys from the OS and instead
+            // simply always called `rand::thread_rng().gen()` twice. In #31356 it
+            // was discovered, however, that because we re-seed the thread-local RNG
+            // from the OS periodically that this can cause excessive slowdown when
+            // many hash maps are created on a thread. To solve this performance
+            // trap we cache the first set of randomly generated keys per-thread.
+            //
+            // Later in #36481 it was discovered that exposing a deterministic
+            // iteration order allows a form of DOS attack. To counter that we
+            // increment one of the seeds on every RandomState creation, giving
+            // every corresponding HashMap a different iteration order.
+            thread_local!(static KEYS: Cell<(u64, u64)> = {
+                Cell::new(sys::hashmap_random_keys())
+            });
 
-        KEYS.with(|keys| {
-            let (k0, k1) = keys.get();
-            keys.set((k0.wrapping_add(1), k1));
-            RandomState { k0, k1 }
-        })
+            KEYS.with(|keys| {
+                let (k0, k1) = keys.get();
+                keys.set((k0.wrapping_add(1), k1));
+                RandomState { k0, k1 }
+            })
+        }
     }
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1052,24 +1052,31 @@ pub struct ThreadId(NonZeroU64);
 impl ThreadId {
     // Generate a new unique thread ID.
     fn new() -> ThreadId {
-        // It is UB to attempt to acquire this mutex reentrantly!
-        static GUARD: mutex::StaticMutex = mutex::StaticMutex::new();
-        static mut COUNTER: u64 = 1;
+        if cfg!(not(any(target_arch = "bpf", target_arch = "sbf"))) {
+            // It is UB to attempt to acquire this mutex reentrantly!
+            static GUARD: mutex::StaticMutex = mutex::StaticMutex::new();
+            static mut COUNTER: u64 = 1;
 
-        unsafe {
-            let guard = GUARD.lock();
+            unsafe {
+                let guard = GUARD.lock();
 
-            // If we somehow use up all our bits, panic so that we're not
-            // covering up subtle bugs of IDs being reused.
-            if COUNTER == u64::MAX {
-                drop(guard); // in case the panic handler ends up calling `ThreadId::new()`, avoid reentrant lock acquire.
-                panic!("failed to generate unique thread ID: bitspace exhausted");
+                // If we somehow use up all our bits, panic so that we're not
+                // covering up subtle bugs of IDs being reused.
+                if COUNTER == u64::MAX {
+                    drop(guard); // in case the panic handler ends up calling `ThreadId::new()`, avoid reentrant lock acquire.
+                    panic!("failed to generate unique thread ID: bitspace exhausted");
+                }
+
+                let id = COUNTER;
+                COUNTER += 1;
+
+                ThreadId(NonZeroU64::new(id).unwrap())
             }
-
-            let id = COUNTER;
-            COUNTER += 1;
-
-            ThreadId(NonZeroU64::new(id).unwrap())
+        } else {
+            // threads are not supported in sbf, so this isn't actually used
+            // anywhere. This branch of the if is only to avoid creating static
+            // mutable data.
+            ThreadId(NonZeroU64::new(1).unwrap())
         }
     }
 

--- a/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
+++ b/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
@@ -21,7 +21,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/solana-labs/cargo-run-bpf-tests.git \
-                  --bin cargo-run-bpf-tests --root /usr/local
+    --rev 4cae9c0 \
+    --bin cargo-run-bpf-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
@@ -30,7 +31,7 @@ ENV RUST_CONFIGURE_ARGS \
     --set rust.lld \
     --set llvm.clang
 
-ENV SCRIPT CARGO_TARGET_BPFEL_UNKNOWN_UNKNOWN_RUNNER=cargo-run-bpf-tests \
+ENV SCRIPT CARGO_TARGET_BPFEL_UNKNOWN_UNKNOWN_RUNNER=\"cargo-run-bpf-tests --heap-size 104857600\" \
     LLVM_HOME=/checkout/obj/build/x86_64-unknown-linux-gnu/llvm \
     PATH="${HOME}/.cargo/bin:${PATH}" \
     python3 /checkout/x.py --stage 1 test --host='' --target bpfel-unknown-unknown \


### PR DESCRIPTION
This makes all the core tests pass, except atomics, which crash LLVM and I'm going to fix next.

The PR:

- Removes the use of thread_local!()s. The API can't be implemented without adding rbpf shims, which seems pointless.
- Makes std::collections::{HashMap, HashSet} work using a hardcoded seed for the map state. Since computation is budgeted it makes no sense for people to try and dos the hasher.
- Hardcodes ThreadId::new() to return 1, disabling upstream code that creates static muts.
- Re-enables UpperExp / LowerExp impls - only float code stays disabled
- Reduces stack size in some tests.
- Hardcodes a static seed in tests that use the rand crate.