### PR TITLE
[SOL] Bump cargo-run-bpf-tests in CI docker file for bpfel

### DIFF
--- a/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
+++ b/src/ci/docker/host-x86_64/bpfel-unknown-unknown/Dockerfile
@@ -21,7 +21,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/solana-labs/cargo-run-bpf-tests.git \
-    --rev 4cae9c0 \
+    --rev e03e1da \
     --bin cargo-run-bpf-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/


### PR DESCRIPTION
I'm not sure, do we need to use an explicit revision?