### PR TITLE
[SOL] CI: speed up PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       CI_JOB_NAME: "${{ matrix.name }}"
       SCCACHE_BUCKET: cached-ci-artifacts
       SCCACHE_REGION: us-east-2
+      SCCACHE_S3_NO_CREDENTIALS: 1
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
     if: "github.event_name == 'pull_request'"

--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -21,7 +21,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/solana-labs/cargo-run-bpf-tests.git \
-    --rev e03e1da \
+    --rev 3d628c7 \
     --bin cargo-run-bpf-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -161,6 +161,7 @@ args=
 if [ "$SCCACHE_BUCKET" != "" ]; then
     args="$args --env SCCACHE_BUCKET"
     args="$args --env SCCACHE_REGION"
+    args="$args --env SCCACHE_S3_NO_CREDENTIALS"
     args="$args --env AWS_ACCESS_KEY_ID"
     args="$args --env AWS_SECRET_ACCESS_KEY"
 else

--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -6,7 +6,7 @@ set -ex
 
 case "$(uname -m)" in
     x86_64)
-        url="https://cached-ci-artifacts.s3.us-east-2.amazonaws.com/sccache-bc014e0-x86_64-unknown-linux-musl"
+        url="https://cached-ci-artifacts.s3.us-east-2.amazonaws.com/sccache-5d2a373-x86_64-unknown-linux-musl"
         ;;
     aarch64)
         url="https://ci-mirrors.rust-lang.org/rustc/2021-08-25-sccache-v0.2.15-aarch64-unknown-linux-musl"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -35,6 +35,7 @@ x--expand-yaml-anchors--remove:
   - &public-variables
     SCCACHE_BUCKET: cached-ci-artifacts
     SCCACHE_REGION: us-east-2
+    SCCACHE_S3_NO_CREDENTIALS: 1
     TOOLSTATE_REPO: https://github.com/rust-lang-nursery/rust-toolstate
     CACHE_DOMAIN: cached-ci-artifacts.s3.us-east-2.amazonaws.com
 


### PR DESCRIPTION
This deploys my sccache fork with support for SCCACHE_S3_NO_CREDENTIALS, which allows PR jobs to read from the cache without requiring AWS credentials. Brings PR test times down to 1h on par with push jobs.