### PR TITLE
[SOL] Don't create invalid string slices in stdout/stderr on Solana

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -339,7 +339,7 @@ pub fn rust_oom(_layout: Layout) -> ! {
     }
     #[cfg(any(target_arch = "bpf", target_arch = "sbf"))]
     {
-        crate::sys::sol_log("Error: memory allocation failed, out of memory");
+        crate::sys::sol_log(b"Error: memory allocation failed, out of memory");
     }
     crate::process::abort()
 }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -912,9 +912,7 @@ impl Write for Stdout {
 #[cfg(any(target_arch = "bpf", target_arch = "sbf"))]
 impl Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(buf.len())
     }
     fn write_vectored(&mut self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
@@ -928,9 +926,7 @@ impl Write for Stdout {
         Ok(())
     }
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(())
     }
     fn write_all_vectored(&mut self, _bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
@@ -1237,9 +1233,7 @@ impl Write for Stderr {
 #[cfg(any(target_arch = "bpf", target_arch = "sbf"))]
 impl Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(buf.len())
     }
     fn write_vectored(&mut self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
@@ -1253,9 +1247,7 @@ impl Write for Stderr {
         Ok(())
     }
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(())
     }
     fn write_all_vectored(&mut self, _bufs: &mut [IoSlice<'_>]) -> io::Result<()> {

--- a/library/std/src/sys/sbf/mod.rs
+++ b/library/std/src/sys/sbf/mod.rs
@@ -49,7 +49,7 @@ extern "C" {
     fn sol_log_(message: *const u8, length: u64);
 }
 
-pub fn sol_log(message: &str) {
+pub fn sol_log(message: &[u8]) {
     unsafe {
         sol_log_(message.as_ptr(), message.len() as u64);
     }

--- a/library/std/src/sys/sbf/stdio.rs
+++ b/library/std/src/sys/sbf/stdio.rs
@@ -18,9 +18,7 @@ impl Stdout {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(buf.len())
     }
 
@@ -34,9 +32,7 @@ impl Stderr {
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe {
-            crate::sys::sol_log(core::str::from_utf8_unchecked(buf));
-        }
+        crate::sys::sol_log(buf);
         Ok(buf.len())
     }
 


### PR DESCRIPTION
While this is no longer considered language-level undefined behavior, it is a violation of library invariants and isn't necessary.