### PR TITLE
Sol/linker script

### DIFF
--- a/compiler/rustc_target/src/spec/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/sbf_base.rs
@@ -8,6 +8,7 @@ PHDRS
 {
   text PT_LOAD ;
   rodata PT_LOAD ;
+  data PT_LOAD ;
   dynamic PT_DYNAMIC ;
 }
 
@@ -18,6 +19,14 @@ SECTIONS
   .rodata : { *(.rodata*) } :rodata
   .data.rel.ro : { *(.data.rel.ro*) } :rodata
   .dynamic : { *(.dynamic) } :dynamic
+  .dynsym : { *(.dynsym) } :data
+  .dynstr : { *(.dynstr) } :data
+  .rel.dyn : { *(.rel.dyn) } :data
+  /DISCARD/ : {
+      *(.eh_frame*)
+      *(.gnu.hash*)
+      *(.hash*)
+    }
 }
 ";
     let mut lld_args = Vec::new();


### PR DESCRIPTION
Tweak the linker script ensuring that all read only sections end up in one segment, and everything else
in other segments. This is needed so rbpf can borrow the whole rodata segment.

Also discard .eh_frame, .hash and .gnu.hash since they are unused.