### PR TITLE
[SOL] Enable the std backtrace API

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -21,7 +21,6 @@ use core::convert::Infallible;
 
 use crate::alloc::{AllocError, LayoutError};
 use crate::any::TypeId;
-#[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
 use crate::backtrace::Backtrace;
 use crate::borrow::Cow;
 use crate::cell;
@@ -133,7 +132,6 @@ pub trait Error: Debug + Display {
     /// `Backtrace` may actually be empty. For more information consult the
     /// `Backtrace` type itself.
     #[unstable(feature = "backtrace", issue = "53487")]
-    #[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
     fn backtrace(&self) -> Option<&Backtrace> {
         None
     }
@@ -534,7 +532,6 @@ impl<'a, T: Error + ?Sized> Error for &'a T {
         Error::source(&**self)
     }
 
-    #[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
     fn backtrace(&self) -> Option<&Backtrace> {
         Error::backtrace(&**self)
     }
@@ -556,7 +553,6 @@ impl<T: Error + ?Sized> Error for Arc<T> {
         Error::source(&**self)
     }
 
-    #[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
     fn backtrace(&self) -> Option<&Backtrace> {
         Error::backtrace(&**self)
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -497,7 +497,6 @@ pub mod f64;
 #[macro_use]
 pub mod thread;
 pub mod ascii;
-#[cfg(all(not(target_arch = "bpf"), not(target_arch = "sbf")))]
 pub mod backtrace;
 pub mod collections;
 pub mod env;


### PR DESCRIPTION
This patch enables the `std::backtrace` and `std::error::Error::backtrace` APIs on the bpf and sbf architectures, always returning appropriate "unsupported" results.

It accomplishes this by hacking up `std/src/backtrace.rs` as little as possible. The code does end up with a lot of cfgs though. Creating a more minimal patch while also minimizing binary size would take upstream work to improve the internal abstractions.

If no backtrace APIs are used by a program, then the resulting binary size after this patch is the same as before this patch.

If a program creates a `dyn Error` trait object that implements the default empty `Error::backtrace` function the resulting binary contains an additional 112 bytes as a result of this patch, 16 bytes of program text for the `Error::backtrace` function, the rest metadata about that function.

I have manually tested that the resulting toolchain produces binaries that can be deployed to solana and that the backtrace APIs work, and that the anyhow crate builds and works. I have not added any unit tests for this as I don't know how the bpf toolchain is tested but I am happy to add tests with direction.

Fixes https://github.com/solana-labs/rust/issues/51