### PR TITLE
sbf: implement static-syscalls target feature

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -223,6 +223,9 @@ const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
 
 const BPF_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[("alu32", Some(sym::bpf_target_feature))];
 
+const SBF_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] =
+    &[("alu32", Some(sym::sbf_target_feature)), ("static-syscalls", Some(sym::sbf_target_feature))];
+
 /// When rustdoc is running, provide a list of all known features so that all their respective
 /// primitives may be documented.
 ///
@@ -238,6 +241,7 @@ pub fn all_known_features() -> impl Iterator<Item = (&'static str, Option<Symbol
         .chain(RISCV_ALLOWED_FEATURES.iter())
         .chain(WASM_ALLOWED_FEATURES.iter())
         .chain(BPF_ALLOWED_FEATURES.iter())
+        .chain(SBF_ALLOWED_FEATURES.iter())
         .cloned()
 }
 
@@ -252,7 +256,7 @@ pub fn supported_target_features(sess: &Session) -> &'static [(&'static str, Opt
         "riscv32" | "riscv64" => RISCV_ALLOWED_FEATURES,
         "wasm32" | "wasm64" => WASM_ALLOWED_FEATURES,
         "bpf" => BPF_ALLOWED_FEATURES,
-        "sbf" => BPF_ALLOWED_FEATURES,
+        "sbf" => SBF_ALLOWED_FEATURES,
         _ => &[],
     }
 }

--- a/library/std/src/sys/sbf/alloc.rs
+++ b/library/std/src/sys/sbf/alloc.rs
@@ -32,6 +32,15 @@ unsafe impl GlobalAlloc for System {
     //     // 0 as *mut u8
     // }
 }
+
+#[cfg(not(target_feature = "static-syscalls"))]
 extern "C" {
     fn sol_alloc_free_(size: u64, ptr: u64) -> *mut u8;
+}
+
+#[cfg(target_feature = "static-syscalls")]
+fn sol_alloc_free_(size: u64, ptr: u64) -> *mut u8 {
+    let syscall: extern "C" fn(u64, u64) -> *mut u8 =
+        unsafe { core::mem::transmute(2213547663u64) }; // murmur32 hash of "sol_alloc_free_"
+    syscall(size, ptr)
 }


### PR DESCRIPTION
Expose static-syscalls as a rust target-feature so it can be used with conditional compilation and implement sol_log_(), abort() and sol_alloc_free_() as static syscalls.