### PR TITLE
Add sbfv2 linker opts

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -360,6 +360,7 @@ impl<'a> GccLinker<'a> {
                 if self.sess.opts.cg.target_cpu.as_ref().unwrap_or(&self.sess.target.cpu) == "sbfv2"
                 {
                     self.linker_arg("--section-start=.text=0x100000000");
+                    self.linker_arg("--pack-dyn-relocs=relr");
                 }
             }
         }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -357,6 +357,10 @@ impl<'a> GccLinker<'a> {
                 } else {
                     self.linker_arg("--entry=entrypoint");
                 }
+                if self.sess.opts.cg.target_cpu.as_ref().unwrap_or(&self.sess.target.cpu) == "sbfv2"
+                {
+                    self.linker_arg("--section-start=.text=0x100000000");
+                }
             }
         }
     }


### PR DESCRIPTION
This places the rodata segment at `MM_PROGRAM_START` and moves _RELATIVE relocations to `SHT_RELR`. Boy bye relocations 👋