### PR TITLE
[SOL] Add solana-lldb wrapper

### DIFF
--- a/src/etc/solana-lldb
+++ b/src/etc/solana-lldb
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Exit if anything fails
+set -e
+
+# Find the host triple so we can find lldb in rustlib.
+host=$(rustc -vV | sed -n -e 's/^host: //p')
+
+# Find out where to look for the pretty printer Python module
+RUSTC_SYSROOT=$(rustc --print sysroot)
+RUST_LLDB="$RUSTC_SYSROOT/lib/rustlib/$host/bin/lldb"
+
+lldb=lldb
+if [ -f "$RUST_LLDB" ]; then
+    lldb="$RUST_LLDB"
+else
+    if ! command -v "$lldb" > /dev/null; then
+        echo "$lldb not found! Please install it." >&2
+        exit 1
+    else
+        LLDB_VERSION=$("$lldb" --version | cut -d ' ' -f3)
+
+        if [ "$LLDB_VERSION" = "3.5.0" ]; then
+            cat << EOF >&2
+***
+WARNING: This version of LLDB has known issues with Rust and cannot display the contents of local variables!
+***
+EOF
+        fi
+    fi
+fi
+
+script_import="command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_lookup.py\""
+script_import_solana="command script import \"solana_lookup.py\""
+commands_file="$RUSTC_SYSROOT/lib/rustlib/etc/lldb_commands"
+commands_file_solana="solana_commands"
+
+# Call LLDB with the commands added to the argument list
+exec "$lldb" --one-line-before-file "$script_import" --one-line-before-file "$script_import_solana" --source-before-file "$commands_file" --source-before-file "$commands_file_solana" "$@"

--- a/src/etc/solana_commands
+++ b/src/etc/solana_commands
@@ -1,0 +1,3 @@
+type summary add -F solana_lookup.summary_lookup solana_program::account_info::AccountInfo --category Solana
+type summary add -F solana_lookup.summary_lookup solana_program::pubkey::Pubkey --category Solana
+type category enable Solana

--- a/src/etc/solana_lookup.py
+++ b/src/etc/solana_lookup.py
@@ -1,0 +1,12 @@
+from solana_providers import *
+from solana_types import SolanaType, classify_solana_type
+
+
+def summary_lookup(valobj, dict):
+    # type: (SBValue, dict) -> str
+    """Returns the summary provider for the given value"""
+    solana_type = classify_solana_type(valobj.GetType())
+    if solana_type == SolanaType.PUBKEY:
+        return PubkeySummaryProvider(valobj, dict)
+    if solana_type == SolanaType.ACCOUNT_INFO:
+        return AccountInfoSummaryProvider(valobj, dict)

--- a/src/etc/solana_providers.py
+++ b/src/etc/solana_providers.py
@@ -1,0 +1,80 @@
+import lldb
+
+
+def encode_b58(num):
+    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    b58 = ""
+    while num != 0:
+        b58 += alphabet[num % 58]
+        num //= 58
+    return b58[::-1]
+
+def PubkeySummaryProvider(valobj, internal_dict):
+    err = lldb.SBError()
+    if valobj.TypeIsPointerType():
+        program_id_type = valobj.GetType().GetPointeeType()
+        value = valobj.GetPointeeData()
+    else:
+        value = valobj.GetData()
+    pubkey = [value.GetUnsignedInt8(err, i) for i in range(32)]
+    pubkey = ''.join("{0:0{1}x}".format(i, 2) for i in pubkey)
+    pubkey = encode_b58(int(pubkey, 16))
+
+    if valobj.TypeIsPointerType():
+        return "-> Pubkey = {}".format(pubkey)
+    return "{}".format(pubkey)
+
+
+def AccountInfoSummaryProvider(valobj, internal_dict):
+    err = lldb.SBError()
+    # key
+    key_valobj = valobj.GetChildAtIndex(0)
+
+    # is_signer
+    signer_valobj = valobj.GetChildAtIndex(1)
+
+    # is_writeable
+    writeable_valobj = valobj.GetChildAtIndex(2)
+
+    # lamports
+    lamport_valobj = valobj.GetChildAtIndex(3)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamport_valobj = lamport_valobj.GetChildAtIndex(0)
+    lamports_data = lamport_valobj.GetData();
+    lamports = lamports_data.GetUnsignedInt64(err, 0)
+
+    # data
+    data_valobj = valobj.GetChildAtIndex(4)
+    data_valobj = data_valobj.GetChildAtIndex(0)
+    data_valobj = data_valobj.GetChildAtIndex(0)
+    data_valobj = data_valobj.__str__().replace("value", "data")
+    data_valobj = data_valobj.__str__().replace("  [", "        [")
+    data_valobj = data_valobj.__str__().replace("}", "    }")
+
+    # owner
+    owner_valobj = valobj.GetChildAtIndex(5)
+
+    # executable
+    executable_valobj = valobj.GetChildAtIndex(6)
+
+    # rent_epoch
+    rent_epoch_valobj = valobj.GetChildAtIndex(7)
+    rent_epoch_data = rent_epoch_valobj.GetData();
+    rent_epoch = rent_epoch_data.GetUnsignedInt64(err, 0)
+
+    ret_string = ""
+    if valobj.TypeIsPointerType():
+        ret_string = "-> "
+
+    return ret_string + """{{
+  {}
+  {}
+  {}
+  (u64) lamports = {}
+  {}
+  {}
+  {}
+  (u64) rent_epoch = {}
+}}
+            """.format(key_valobj, signer_valobj, writeable_valobj, lamports, owner_valobj, executable_valobj, data_valobj, rent_epoch)

--- a/src/etc/solana_types.py
+++ b/src/etc/solana_types.py
@@ -1,0 +1,19 @@
+import re
+
+
+class SolanaType(object):
+    PUBKEY = "Pubkey"
+    ACCOUNT_INFO = "AccountInfo"
+
+PUBKEY_REGEX = re.compile(r"^(solana_program::pubkey::Pubkey)")
+ACCOUNT_INFO_REGEX = re.compile(r"^(solana_program::account_info::AccountInfo)")
+
+SOLANA_TYPE_TO_REGEX = {
+    SolanaType.PUBKEY: PUBKEY_REGEX,
+    SolanaType.ACCOUNT_INFO: ACCOUNT_INFO_REGEX,
+}
+
+def classify_solana_type(type):
+    for ty, regex in SOLANA_TYPE_TO_REGEX.items():
+        if regex.match(type.name):
+            return ty


### PR DESCRIPTION
This adds a wrapper around the system wide installed LLDB similiar to `rust-lldb`, including two helper functions to print solana types (e.g. pubkeys in base58). Once we start to distribute LLDB in sbf-tools, we have to invoke the custom LLDB from solana-labs/llvm-project in the `solana-lldb` script. This commit is only adding the `wrapper` and `python scripts`, which would have to be distributed together.