### PR TITLE
[SOL] Set default visibility of symbols in SBF binaries to hidden

### DIFF
--- a/compiler/rustc_target/src/spec/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/sbf_base.rs
@@ -36,6 +36,7 @@ SECTIONS
     TargetOptions {
         allow_asm: true,
         c_int_width: "64".into(),
+        default_hidden_visibility: true,
         dll_prefix: "".into(),
         dynamic_linking: true,
         eh_frame_header: false,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -401,6 +401,7 @@ pub mod __alloc_error_handler {
     // called via generated `__rust_alloc_error_handler` if there is no
     // `#[alloc_error_handler]`.
     #[rustc_std_internal_symbol]
+    #[cfg(not(target_family = "solana"))]
     pub unsafe fn __rdl_oom(size: usize, _align: usize) -> ! {
         extern "Rust" {
             // This symbol is emitted by rustc next to __rust_alloc_error_handler.
@@ -416,6 +417,14 @@ pub mod __alloc_error_handler {
                 "memory allocation of {size} bytes failed"
             ))
         }
+    }
+
+    #[rustc_std_internal_symbol]
+    #[cfg(target_family = "solana")]
+    pub unsafe fn __rdl_oom(size: usize, _align: usize) -> ! {
+        core::panicking::panic_nounwind_fmt(format_args!(
+            "memory allocation of {size} bytes failed"
+        ))
     }
 }
 

--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/solana-labs/cargo-run-solana-tests.git \
-    --rev 12186c99173cc30771897932159b53acca836321 \
+    --rev 6d90ebb6bde748a4ce6f415ed85dc3fb42b1e97b \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/


### PR DESCRIPTION
Make a solana specific version of __rdl_oom handler that doesn't use a
static variable.  This variable can't be supported is Solana execution
environment.
