### PR TITLE
Bugfix: allow arm64 as output of uname -m

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ unameOut="$(uname -s)-$(uname -m)"
 case "${unameOut}" in
     Linux-x86_64*)  HOST_TRIPLE=x86_64-unknown-linux-gnu;;
     Linux-aarch64*) HOST_TRIPLE=aarch64-unknown-linux-gnu;;
+    Linux-arm64*)   HOST_TRIPLE=aarch64-unknown-linux-gnu;;
     Darwin-x86_64*) HOST_TRIPLE=x86_64-apple-darwin;;
     Darwin-arm64*)  HOST_TRIPLE=aarch64-apple-darwin;;
     MINGW*)         HOST_TRIPLE=x86_64-pc-windows-msvc;;


### PR DESCRIPTION
> While trying to build an ARM container for Solana contract CI, the [build.sh](https://github.com/solana-labs/platform-tools/blob/v1.37/build.sh#L48) script of the `platform-tools` calls the `build.sh` script here.

> When it returns, the `HOST_TRIPLE` env var has been overwritten to `x86_64-unknown-linux-gnu`which causes the following steps in `platform-tools/build.sh` to execute incorrectly. 

> This change adds another option for the output of `uname -m` to match the `platform-tools/build.sh` so the `HOST_TRIPLE` there does not get rugged

The actual fix for the issue I was having:
https://github.com/solana-labs/platform-tools/pull/71