### PR TITLE
[SOL] Set 32 bits for SBF minimum enum size

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -60,6 +60,7 @@ SECTIONS
         requires_lto: false,
         singlethread: true,
         vendor: "solana".into(),
+        c_enum_min_bits: Some(32),
         .. Default::default()
     }
 }


### PR DESCRIPTION
When using `#[repr(C]` on an enum in Rust, its size used to be 32-bits. However, https://github.com/rust-lang/rust/pull/107592 changed it to the target's `c_int` size, which is 64-bits for SBF.

As a consequence, the enum size is inconsistent between versions of the platform tools. A `#[repr(C)]` enum was 4 bytes in v1.37 and became 8 bytes in v1.39. This PR sets the enum size for 32-bits in SBF, as it used to be before the change.