### PR TITLE
[SOL] Update SBF call ABI

### DIFF
--- a/compiler/rustc_target/src/abi/call/sbf.rs
+++ b/compiler/rustc_target/src/abi/call/sbf.rs
@@ -1,23 +1,33 @@
 // see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/BPF/BPFCallingConv.td
-use crate::abi::call::{ArgAbi, FnAbi};
+use crate::abi::call::{ArgAbi, FnAbi, Reg, Uniform};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() || ret.layout.size.bits() > 64 {
-        if ret.layout.size.bits() != 128 {
-            ret.make_indirect();
-        }
-    } else {
+    let size = ret.layout.size;
+    let bits = size.bits();
+    if !ret.layout.is_aggregate() && bits <= 64 {
         ret.extend_integer_width_to(64);
+        return;
+    }
+
+    if bits <= 128 {
+        ret.cast_to(Uniform {unit: Reg::i64(), total: size});
+    } else {
+        ret.make_indirect();
     }
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() || arg.layout.size.bits() > 64 {
-        if arg.layout.size.bits() != 128 {
-            arg.make_indirect();
-        }
-    } else {
+    let size = arg.layout.size;
+    let bits = size.bits();
+    if !arg.layout.is_aggregate() && bits <= 64 {
         arg.extend_integer_width_to(64);
+        return;
+    }
+
+    if bits <= 128 {
+        arg.cast_to(Uniform {unit: Reg::i64(), total: size});
+    } else {
+        arg.make_indirect();
     }
 }
 


### PR DESCRIPTION
**Problem**

Since commit https://github.com/anza-xyz/rust/commit/c9810261956faa1152ade6a37efe6583b2caaa20, the Rust compiler does not allow targets to leak aggregate types to an external ABI. As a consequence, compiling a function `extern fn foo(arg: [u8; 16])` for Solana would hit the assertion: 

https://github.com/anza-xyz/rust/blob/6cc5efcd78429dde832e7ec5c55c5889af8fc62e/compiler/rustc_codegen_llvm/src/abi.rs#L369-L374

**Solution**

I updated the SBF's ABI convention to use 64-bit registers when possible and pass arguments/returns indirectly if they are Rust aggregates.