### PR TITLE
[SOL] Revert "Update syscalls num (#97)"

### DIFF
--- a/library/std/src/sys/pal/sbf/alloc.rs
+++ b/library/std/src/sys/pal/sbf/alloc.rs
@@ -41,6 +41,6 @@ extern "C" {
 #[cfg(target_feature = "static-syscalls")]
 fn sol_alloc_free_(size: u64, ptr: u64) -> *mut u8 {
     let syscall: extern "C" fn(u64, u64) -> *mut u8 =
-        unsafe { core::mem::transmute(11usize) }; // 11 is the code for "sol_alloc_free_"
+        unsafe { core::mem::transmute(2213547663u64) }; // murmur32 hash of "sol_alloc_free_"
     syscall(size, ptr)
 }

--- a/library/std/src/sys/pal/sbf/mod.rs
+++ b/library/std/src/sys/pal/sbf/mod.rs
@@ -47,13 +47,13 @@ extern "C" {
 
 #[cfg(target_feature = "static-syscalls")]
 unsafe extern "C" fn abort() -> ! {
-    let syscall: extern "C" fn() -> ! = core::mem::transmute(1usize); // 1 is the code for "abort"
+    let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
     syscall()
 }
 
 #[cfg(target_feature = "static-syscalls")]
 unsafe extern "C" fn sol_log_(message: *const u8, length: u64) {
-    let syscall: extern "C" fn(*const u8, u64) = core::mem::transmute(7usize); // 7 is the code for "sol_log_"
+    let syscall: extern "C" fn(*const u8, u64) = core::mem::transmute(544561597u64); // murmur32 hash of "sol_log_"
     syscall(message, length)
 }
 
@@ -68,8 +68,6 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         #[cfg(not(target_feature = "static-syscalls"))]
         custom_panic(info);
 
-        // FIXME: This implementation needs a revision in tandem with
-        // https://github.com/anza-xyz/agave/pull/3951
         #[cfg(target_feature = "static-syscalls")]
         sol_log(info.to_string().as_bytes());
 

--- a/library/std/src/sys/pal/sbf/mod.rs
+++ b/library/std/src/sys/pal/sbf/mod.rs
@@ -68,6 +68,8 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         #[cfg(not(target_feature = "static-syscalls"))]
         custom_panic(info);
 
+        // FIXME: This implementation needs a revision in tandem with
+        // https://github.com/anza-xyz/agave/pull/3951
         #[cfg(target_feature = "static-syscalls")]
         sol_log(info.to_string().as_bytes());
 


### PR DESCRIPTION
As per the [conversation thread](https://github.com/solana-foundation/solana-improvement-documents/pull/178#discussion_r1927605962) in [SIMD-0178](https://github.com/solana-foundation/solana-improvement-documents/pull/178), we are going to continue using murmur32 hashes for syscall identification.