### PR TITLE
Test SBPFv1 and SBPFv2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
             tidy: false
             os: ubuntu-latest
             env: {}
+          - name: sbf-solana-solana-v1
+            tidy: false
+            os: ubuntu-latest
+            env: {}
+          - name: sbf-solana-solana-v2
+            tidy: false
+            os: ubuntu-latest
+            env: {}
           - name: x86_64-gnu-tools
             os: ubuntu-latest
             env: {}
@@ -197,6 +205,12 @@ jobs:
             os: ubuntu-latest
             env: {}
           - name: sbf-solana-solana
+            os: ubuntu-latest
+            env: {}
+          - name: sbf-solana-solana-v1
+            os: ubuntu-latest
+            env: {}
+          - name: sbf-solana-solana-v2
             os: ubuntu-latest
             env: {}
     defaults:

--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev d6ae9918ef1bc1049dabc2ded490460515f777d4 \
+    --rev 3bbd9252ac68c1edb54d2a89fa6ee794a0bbd7c2 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -369,6 +369,14 @@ jobs:
             <<: *job-linux-16c
             tidy: false
 
+          - name: sbf-solana-solana-v1
+            <<: *job-linux-16c
+            tidy: false
+
+          - name: sbf-solana-solana-v2
+            <<: *job-linux-16c
+            tidy: false
+
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
 
@@ -389,6 +397,13 @@ jobs:
 
           - name: sbf-solana-solana
             <<: *job-linux-16c
+
+          - name: sbf-solana-solana-v1
+            <<: *job-linux-16c
+
+          - name: sbf-solana-solana-v2
+            <<: *job-linux-16c
+
 
   auto:
     <<: *base-ci-job

--- a/src/ci/scripts/run-build-from-ci.sh
+++ b/src/ci/scripts/run-build-from-ci.sh
@@ -18,6 +18,14 @@ echo "::add-matcher::src/ci/github-actions/problem_matchers.json"
 rustup self uninstall -y || true
 if [ -z "${IMAGE+x}" ]; then
     src/ci/run.sh
+elif [ "$IMAGE" == "sbf-solana-solana-v1" ]; then
+    sed -i -e 's/.. Default::default()/cpu: "v1".into(), \n \t\t.. Default::default()/g' \
+     compiler/rustc_target/src/spec/base/sbf_base.rs
+    src/ci/docker/run.sh sbf-solana-solana
+elif [ "$IMAGE" == "sbf-solana-solana-v2" ]; then
+    sed -i -e 's/.. Default::default()/cpu: "v2".into(), \n \t\t.. Default::default()/g' \
+     compiler/rustc_target/src/spec/base/sbf_base.rs
+    src/ci/docker/run.sh sbf-solana-solana
 else
     src/ci/docker/run.sh "${IMAGE}"
 fi


### PR DESCRIPTION
Tests for SBPFv3 require that SBPF v0.10.0 be integrated in Agave due to the new murmur32 syscall codes. An Agave version compatible with v0.10.0 is a dependency of [cargo-run-solana-tests](https://github.com/anza-xyz/cargo-run-solana-tests), used in CI.