### PR TITLE
[SOL] Implement empty weak custom panic

### DIFF
--- a/library/std/src/sys/pal/sbf/mod.rs
+++ b/library/std/src/sys/pal/sbf/mod.rs
@@ -43,10 +43,10 @@ extern "C" {
     fn sol_log_(message: *const u8, length: u64);
 }
 
-extern "C" {
-    #[allow(improper_ctypes)]
-    fn custom_panic(info: &core::panic::PanicInfo<'_>);
-}
+#[no_mangle]
+#[allow(improper_ctypes)]
+#[linkage = "weak"]
+extern "C" fn custom_panic(_info: &core::panic::PanicInfo<'_>) {}
 
 #[cfg(target_feature = "static-syscalls")]
 unsafe extern "C" fn abort() -> ! {


### PR DESCRIPTION
Having an empty custom panic with weak linkage, instead of simply its header, permits a program to work correctly even when not using the SDK.

If one avoids the Solana SDK and doesn't implement a custom panic, the program has an undefined symbol. On SBPFv3, in particular, as we have no relocations, that translates to `call -1` instruction, leading to an infinite loop.