### PR TITLE
[SOL] Place abort at address zero

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -32,6 +32,8 @@ const V3_LINKER_SCRIPT: &str = r"
 SECTIONS
 {
   .text 0x000000000 : {
+    . = 0x00;
+    KEEP(*(.text.abort_v3))
      *(.text*)
   } :text
   .rodata 0x100000000 : {

--- a/library/std/src/sys/pal/sbf/mod.rs
+++ b/library/std/src/sys/pal/sbf/mod.rs
@@ -49,7 +49,11 @@ extern "C" {
 }
 
 #[cfg(target_feature = "static-syscalls")]
-unsafe extern "C" fn abort() -> ! {
+#[inline(never)]
+#[no_mangle]
+#[link_section = ".text.abort_v3"]
+#[linkage = "external"]
+pub unsafe extern "C" fn abort() -> ! {
     let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"
     syscall()
 }


### PR DESCRIPTION
In SBPFv3, functions can be at address zero. This particular location creates a problem when dealing with function pointers. It is common practice to consider null pointers (i.e zero valued pointers) as invalid, so most infrastructure was developed around that premise.

When we have assertions enabled in rust std, all function pointers are checked against address zero, even when they  represent a valid function address as in SBPFv3.

To circumvent the problem, we are fixing `fn abort` at address zero. Whenever a program is compiled with cargo, the function will be present at `0x00`. This setting will also mimic what happens on Linux: dereferencing a zero function pointer will cause the program to abort.