### PR TITLE
[SOL] Bump compiler builtins commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "compiler_builtins"
 version = "0.1.112"
-source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.44#59d7315985b3d001ca32fbd29593802148051c8b"
+source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.44#4abd7f45fc621344e4b9d1df37a45b7445f03c71"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\"",
-"\"git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.44#59d7315985b3d001ca32fbd29593802148051c8b\"",
+"\"git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.44#4abd7f45fc621344e4b9d1df37a45b7445f03c71\"",
 "\"git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.44#4f19dfe109fc80efbe62b6de9781125bc7ce7485\""];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
We need the newest commit for #109 to work. I had already tagged compiler-builtins with v1.44 and retagged it to a new commit. As an official release hasn't been cut yet, there is no problem in retagging the repository.