### PR TITLE
[SOL] Use `.text.abort` section for SBPFv3

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -33,7 +33,7 @@ SECTIONS
 {
   .text 0x000000000 : {
     . = 0x00;
-    KEEP(*(.text.abort_v3))
+    KEEP(*(.text.abort))
      *(.text*)
   } :text
   .rodata 0x100000000 : {

--- a/library/std/src/sys/pal/sbf/mod.rs
+++ b/library/std/src/sys/pal/sbf/mod.rs
@@ -51,7 +51,7 @@ extern "C" fn custom_panic(_info: &core::panic::PanicInfo<'_>) {}
 #[cfg(target_feature = "static-syscalls")]
 #[inline(never)]
 #[no_mangle]
-#[link_section = ".text.abort_v3"]
+#[link_section = ".text.abort"]
 #[linkage = "external"]
 pub unsafe extern "C" fn abort() -> ! {
     let syscall: extern "C" fn() -> ! = core::mem::transmute(3069975057u64); // murmur32 hash of "abort"


### PR DESCRIPTION
If someone declares another `abort` function, the linker will error out. On the other hand, if someone declares an `abort_v3` function, it may assume the address zero. Rustc will place it in section `.text.abort_v3`.

Both the linker error with duplicate `abort` and a user defined `abort_v3` being at address zero should be rare occurrances, since they require one of the attributes between `#[linkage = "external"]`, `extern "C"` or `#[no_mangle]`, which are virtually unnecessary in a Solana contract.