### PR TITLE
[SOL] Enable store-imm and less than

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -99,6 +99,7 @@ pub fn opts() -> TargetOptions {
         env: "".into(),
         executables: true,
         families: cvs!["solana"],
+        features: "+store-imm,+jmp-ext".into(),
         link_script: Some(V0_LINKER_SCRIPT.into()),
         linker: Some("rust-lld".into()),
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),


### PR DESCRIPTION
Store imm instructions and less than jumps (`jlt`, `jle`, `jsle`, `jslt`) are available on SBPFv0 and can be enabled right away. They make code generation more efficient and reduce programs size.

Thanks to @febo for pointing out the existing inefficiency.