### PR TITLE
[SOL] Set max page size for program header alignment

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -82,9 +82,18 @@ PHDRS
 ";
 
 pub fn opts(version: &'static str) -> TargetOptions {
+    let mut linker_args: Vec<&str> = vec![
+        "--threads=1", "-z", "notext", "--Bdynamic"
+    ];
+
+    if version != "v3" {
+        linker_args.push("-z");
+        linker_args.push("max-page-size=4096");
+    }
+
     let pre_link_args = TargetOptions::link_args(
         LinkerFlavor::Gnu(Cc::No, Lld::No),
-        &["--threads=1", "-z", "notext", "--Bdynamic"],
+        linker_args.as_slice(),
     );
 
     let linker_script = if version == "v3" {


### PR DESCRIPTION
**Problem**

The LLVM PR https://github.com/anza-xyz/llvm-project/pull/129 changed the `defaultMaxPageSize` for the SBF target to 8. This number is used for aligning sections and program headers. It decreases program size, specifically for SBPFv3.

In SBPFv0, v1, v2, the compiler outputs correct binaries, but a further usage of `llvm-objcopy --strip-all`, included in the `cargo-build-sbf` build pipeline utilizes the segments alignment for calculating the correct offset for the sections it shrinks. When we use the alignment 8, the virtual address and the offset will mismatch, causing the binary to be rejected by the loader.

This is not a problem for SBPFv3, which allows section virtual addresses and offset to diverge.

**Solution**

I'll add `-z max-page-size=4096` as another linker argument when the SBPF version is not v3. This will cause the program header entry to be aligned at 4096 as it was before the https://github.com/anza-xyz/llvm-project/pull/129 change. See:

https://github.com/anza-xyz/llvm-project/blob/6b28be55793bd51260d7ec07c20de483f12383a6/lld/ELF/Writer.h#L28