### PR TITLE
[SOL] Optimize rustlib for size

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -269,7 +269,7 @@ prefix = "opt/sbf-rust"
 # Note: the slowness of the non optimized compiler compiling itself usually
 #       outweighs the time gains in not doing optimizations, therefore a
 #       full bootstrap takes much more time with `optimize` set to false.
-optimize = true
+optimize = "s"
 
 # Indicates that the build should be configured for debugging Rust. A
 # `debug`-enabled compiler and standard library will be somewhat


### PR DESCRIPTION
When we enable ALU32 with SBPFv2 and SBPFv3, rustc starts inlining more functions than before, since they may be smaller. Such aggressive inning increases program size.

Building the rust lib with the "s" option prevents inlining and loop unrolling.

https://github.com/anza-xyz/rust/blob/08b7341888ab480dfaaa0698300cbbbbb2d75b53/config.example.toml#L429-L443