### PR TITLE
[SOL] Bump versions for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 [[package]]
 name = "compiler_builtins"
 version = "0.1.112"
-source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.45#5380e204aab5be48c798679cc52b1f871c8ad4bc"
+source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.46#5380e204aab5be48c798679cc52b1f871c8ad4bc"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "rustc-build-sysroot"
 version = "0.5.3"
-source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.45#06b534a5fcd5dcd7778c0230887ad6fb304d86bc"
+source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.46#469be0287e27b81b84dd4bcf5106a5ff5b7c0b01"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ debug = 0
 strip = true
 
 [patch.crates-io]
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 # See comments in `library/rustc-std-workspace-core/README.md` for what's going on
 # here
 rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }

--- a/compiler/rustc_codegen_gcc/build_sysroot/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/build_sysroot/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 core = { path = "./sysroot_src/library/core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 alloc = { path = "./sysroot_src/library/alloc" }
 std = { path = "./sysroot_src/library/std", features = ["panic_unwind", "backtrace"] }
 test = { path = "./sysroot_src/library/test" }

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" , features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" , features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 core = { path = "../core" }
 unwind = { path = "../unwind" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 cfg-if = "1.0"
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -10,7 +10,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45", features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
 cc = "1.0.90"

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = ['rustc-dep-of-std'] }

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.45" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.46" }
 cfg-if = "1.0"
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/src/tools/miri/cargo-miri/Cargo.toml
+++ b/src/tools/miri/cargo-miri/Cargo.toml
@@ -18,7 +18,7 @@ directories = "5"
 rustc_version = "0.4"
 serde_json = "1.0.40"
 cargo_metadata = "0.18.0"
-rustc-build-sysroot = {git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.45"  }
+rustc-build-sysroot = {git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.46"  }
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 /// List of allowed sources for packages.
 const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\"",
-"\"git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.45#5380e204aab5be48c798679cc52b1f871c8ad4bc\"",
-"\"git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.45#06b534a5fcd5dcd7778c0230887ad6fb304d86bc\""];
+"\"git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.46#5380e204aab5be48c798679cc52b1f871c8ad4bc\"",
+"\"git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.46#469be0287e27b81b84dd4bcf5106a5ff5b7c0b01\""];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.


### PR DESCRIPTION
This update (still on Rust 1.79) is intended to bring https://github.com/anza-xyz/llvm-project/pull/142 in a release, which fixes an issue with stack arguments in SBFPv2.