### PR TITLE
[SOL] Fix CI for PRs

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -198,7 +198,7 @@ pub(crate) fn is_ci_llvm_available(config: &Config, asserts: bool) -> bool {
         ("i686-pc-windows-gnu", false),
         ("i686-pc-windows-msvc", false),
         ("i686-unknown-linux-gnu", false),
-        ("x86_64-unknown-linux-gnu", true),
+        // ("x86_64-unknown-linux-gnu", true),
         ("x86_64-apple-darwin", true),
         ("x86_64-pc-windows-gnu", true),
         ("x86_64-pc-windows-msvc", true),

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -21,6 +21,7 @@ pub(crate) fn parse(config: &str) -> Config {
 }
 
 #[test]
+#[ignore]
 fn download_ci_llvm() {
     let config = parse("");
     let is_available = llvm::is_ci_llvm_available(&config, config.llvm_assertions);

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -858,13 +858,13 @@ pub(crate) fn is_download_ci_available(target_triple: &str, llvm_assertions: boo
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-freebsd",
         "x86_64-unknown-illumos",
-        "x86_64-unknown-linux-gnu",
+        //"x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl",
         "x86_64-unknown-netbsd",
     ];
 
     const SUPPORTED_PLATFORMS_WITH_ASSERTIONS: &[&str] =
-        &["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"];
+        &["x86_64-pc-windows-msvc"];
 
     if llvm_assertions {
         SUPPORTED_PLATFORMS_WITH_ASSERTIONS.contains(&target_triple)

--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -32,6 +32,9 @@ RUN pip3 install --no-deps --no-cache-dir --require-hashes -r /tmp/reuse-require
 COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
+ENV NO_DOWNLOAD_CI_RUSTC 1
+ENV NO_DOWNLOAD_CI_LLVM 1
+
 # NOTE: intentionally uses python2 for x.py so we can test it still works.
 # validate-toolstate only runs in our CI, so it's ok for it to only support python3.
 ENV SCRIPT TIDY_PRINT_DIFF=1 python2.7 ../x.py test \

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -42,6 +42,9 @@ COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
+ENV NO_DOWNLOAD_CI_RUSTC 1
+ENV NO_DOWNLOAD_CI_LLVM 1
+
 
 # Check library crates on all tier 1 targets.
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -84,7 +84,8 @@ ENV RUST_CONFIGURE_ARGS \
   --enable-new-symbol-mangling
 
 ENV HOST_TARGET x86_64-unknown-linux-gnu
-ENV FORCE_CI_RUSTC 1
+ENV NO_DOWNLOAD_CI_RUSTC 1
+ENV NO_DOWNLOAD_CI_LLVM 1
 
 COPY host-x86_64/dist-x86_64-linux/shared.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/build-gccjit.sh /scripts/


### PR DESCRIPTION
The original Rust CI is configured to download rustc and llvm from previously built runs. Since we want to test our own branches, we must not download them.