### PR TITLE
[SOL] Create sbpfv0 target

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1909,6 +1909,7 @@ supported_targets! {
     ("bpfel-unknown-none", bpfel_unknown_none),
     ("sbf-solana-solana", sbf_solana_solana),
     ("sbpf-solana-solana", sbpf_solana_solana),
+    ("sbpfv0-solana-solana", sbpfv0_solana_solana),
     ("sbpfv1-solana-solana", sbpfv1_solana_solana),
     ("sbpfv2-solana-solana", sbpfv2_solana_solana),
     ("sbpfv3-solana-solana", sbpfv3_solana_solana),

--- a/compiler/rustc_target/src/spec/targets/sbpfv0_solana_solana.rs
+++ b/compiler/rustc_target/src/spec/targets/sbpfv0_solana_solana.rs
@@ -1,0 +1,6 @@
+use crate::spec::Target;
+use crate::spec::base::sbf_base;
+
+pub(crate) fn target() -> Target {
+    sbf_base::sbf_target("v0")
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -36,6 +36,7 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
     "sbf-solana-solana",
     "sbpf-solana-solana",
+    "sbpfv0-solana-solana",
     "sbpfv1-solana-solana",
     "sbpfv2-solana-solana",
     "sbpfv3-solana-solana",

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -231,6 +231,7 @@ fn default_compiler(
 
         "sbf-solana-solana"
         | "sbpf-solana-solana"
+        | "sbpfv0-solana-solana"
         | "sbpfv1-solana-solana"
         | "sbpfv2-solana-solana"
         | "sbpfv3-solana-solana" => {

--- a/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
@@ -38,7 +38,8 @@ ENV RUST_CONFIGURE_ARGS \
     --set llvm.clang
 
 ENV SCRIPT CARGO_TARGET_SBPF_SOLANA_SOLANA_RUNNER=\"cargo-run-solana-tests --heap-size 204857600\" \
+    CARGO_TARGET_SBPFV0_SOLANA_SOLANA_RUNNER=\"cargo-run-solana-tests --heap-size 204857600\" \
     LLVM_HOME=/checkout/obj/build/x86_64-unknown-linux-gnu/llvm \
     PATH="${HOME}/.cargo/bin:${PATH}" \
-    python3 /checkout/x.py --stage 1 test --host='' --target sbpf-solana-solana \
+    python3 /checkout/x.py --stage 1 test --host='' --target sbpf-solana-solana,sbpfv0-solana-solana \
     library/core

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -370,6 +370,7 @@ target | std | host | notes
 [`s390x-unknown-linux-musl`](platform-support/s390x-unknown-linux-musl.md) |  |  | S390x Linux (kernel 3.2, musl 1.2.3)
 `sbf-solana-solana` | ✓ |  | SBF
 `sbpf-solana-solana` | ✓ |  | SBPF
+`sbpfv0-solana-solana` | ✓ |  | SBPF v0
 `sbpfv1-solana-solana` | ✓ |  | SBPF v1
 `sbpfv2-solana-solana` | ✓ |  | SBPF v2
 `sbpfv3-solana-solana` | ✓ |  | SBPF v3

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -147,6 +147,7 @@ static TARGETS: &[&str] = &[
     "s390x-unknown-linux-gnu",
     "sbf-solana-solana",
     "sbpf-solana-solana",
+    "sbpfv0-solana-solana",
     "sbpfv1-solana-solana",
     "sbpfv2-solana-solana",
     "sbpfv3-solana-solana",

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -672,6 +672,9 @@
 //@ revisions: sbpf_solana_solana
 //@ [sbpf_solana_solana] compile-flags: --target sbpf-solana-solana
 //@ [sbpf_solana_solana] needs-llvm-components: sbf
+//@ revisions: sbpfv0_solana_solana
+//@ [sbpfv0_solana_solana] compile-flags: --target sbpfv0-solana-solana
+//@ [sbpfv0_solana_solana] needs-llvm-components: sbf
 //@ revisions: sbpfv1_solana_solana
 //@ [sbpfv1_solana_solana] compile-flags: --target sbpfv1-solana-solana
 //@ [sbpfv1_solana_solana] needs-llvm-components: sbf


### PR DESCRIPTION
This was an old request. Having sbpfv0 enables us to switch the default sbpf target to either v1, v2, or v3 when we start deprecating old versions.

PS: I bumped the LLVM PR to bring https://github.com/anza-xyz/llvm-project/pull/148