### PR TITLE
[SOL] Fix SBPFv4 linker invocation

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -451,8 +451,10 @@ impl<'a> GccLinker<'a> {
                 } else {
                     self.link_arg("--entry=entrypoint");
                 }
-                if self.sess.opts.cg.target_cpu.as_ref()
-                    .unwrap_or(&self.sess.target.cpu.as_ref().to_string()) == "v3" {
+
+                let cpu_type = self.sess.opts.cg.target_cpu.as_ref().cloned()
+                    .unwrap_or(self.sess.target.cpu.as_ref().to_string());
+                if cpu_type == "v3" || cpu_type == "v4" {
                     self.link_arg("-Bsymbolic");
                     if self.sess.opts.debuginfo == DebugInfo::None {
                         self.link_arg("--strip-all");

--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -86,21 +86,19 @@ pub(crate) fn opts(version: &'static str) -> TargetOptions {
         "--threads=1", "-z", "notext", "--Bdynamic"
     ];
 
-    if version != "v3" {
+    let linker_script = if version == "v3" || version == "v4" {
+        V3_LINKER_SCRIPT
+    } else {
         linker_args.push("-z");
         linker_args.push("max-page-size=4096");
-    }
+        V0_LINKER_SCRIPT
+    };
 
     let pre_link_args = TargetOptions::link_args(
         LinkerFlavor::Gnu(Cc::No, Lld::No),
         linker_args.as_slice(),
     );
 
-    let linker_script = if version == "v3" || version == "v4" {
-        V3_LINKER_SCRIPT
-    } else {
-        V0_LINKER_SCRIPT
-    };
     let cpu = if version == "v0" {
         "generic"
     } else {


### PR DESCRIPTION
**Problem**

I had created the SBPFv4 target in #130, but I didn't bother to test, since the VM wasn't supporting it yet. With https://github.com/anza-xyz/sbpf/pull/44, I was able to test the generated binaries. I found that I forgot to update the linker invocation commands.

**Changes**

1. Apply to v4 the same linker commands as those for v3.
2. Bump LLVM commit to bring https://github.com/anza-xyz/llvm-project/pull/151.