### PR TITLE
[SOL] Refactor SBPFv3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "rustc-build-sysroot"
 version = "0.5.3"
-source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.49#9b36c221db90c5039463c572ccbb903972bda8ce"
+source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.50#932133f4069426f6b394a82c011c9fdf08b300ff"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 core = { path = "./sysroot_src/library/core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
 alloc = { path = "./sysroot_src/library/alloc" }
 std = { path = "./sysroot_src/library/std", features = ["panic_unwind", "backtrace"] }
 test = { path = "./sysroot_src/library/test" }

--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -54,12 +54,7 @@ SECTIONS
         _heap_end = .;
         . = ALIGN(8);
    } :heap
-  .dynsym 0xFFFFFFFF00000000 : {
-    *(.dynsym)
-    . = ALIGN(8);
-  } :dynsym
    .strtab : { *(.strtab) } :other
-   .dynstr : { *(.dynstr) } :other
   /DISCARD/ : {
       *(.comment*)
       *(.eh_frame*)
@@ -68,15 +63,16 @@ SECTIONS
       *(.data*)
       *(.rel.dyn*)
       *(.dynamic)
+      *(.dynsym)
+      *(.dynstr)
     }
 }
 PHDRS
 {
   text PT_LOAD FLAGS(1);
   rodata PT_LOAD FLAGS(4);
-  stack PT_GNU_STACK FLAGS(6);
+  stack PT_LOAD FLAGS(6);
   heap PT_LOAD FLAGS(6);
-  dynsym PT_NULL FLAGS(0);
   other PT_NULL FLAGS(0);
 }
 ";

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 [[package]]
 name = "compiler_builtins"
 version = "0.1.138"
-source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.49#759adff89713678bfd9c7630fe0f60088f635085"
+source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.50#759adff89713678bfd9c7630fe0f60088f635085"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -45,4 +45,4 @@ rustc-demangle.debug = 0
 rustc-std-workspace-core = { path = 'rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'rustc-std-workspace-std' }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49", features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 core = { path = "../core" }
 unwind = { path = "../unwind" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -10,7 +10,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49", features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
 # FIXME: Pinned due to build error when bumped (#132556)

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.49" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
 cfg-if = "1.0"
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -118,9 +118,9 @@ pr:
   - image: sbpfv2-solana-solana
     continue_on_error: true
     <<: *job-linux-4c
-  - image: sbpfv3-solana-solana
-    continue_on_error: true
-    <<: *job-linux-4c
+#  - image: sbpfv3-solana-solana
+#    continue_on_error: true
+#    <<: *job-linux-4c
 
 # Jobs that run when you perform a try build (@bors try)
 # These jobs automatically inherit envs.try, to avoid repeating

--- a/src/tools/miri/cargo-miri/Cargo.toml
+++ b/src/tools/miri/cargo-miri/Cargo.toml
@@ -18,7 +18,7 @@ directories = "5"
 rustc_version = "0.4"
 serde_json = "1.0.40"
 cargo_metadata = "0.18.0"
-rustc-build-sysroot = { git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.49"  }
+rustc-build-sysroot = { git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.50"  }
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -8,8 +8,8 @@ const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
     r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
-    r#""git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.49#759adff89713678bfd9c7630fe0f60088f635085""#,
-    r#""git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.49#9b36c221db90c5039463c572ccbb903972bda8ce""#
+    r#""git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.50#759adff89713678bfd9c7630fe0f60088f635085""#,
+    r#""git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.50#932133f4069426f6b394a82c011c9fdf08b300ff""#
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
**Description**

We've revised the implementation of SBPFv3, removing the symbol table. This PR brings the necessary changes to emit correct code for it.

**Summary of changes**

1. Bump LLVM commit to bring https://github.com/anza-xyz/llvm-project/pull/158, https://github.com/anza-xyz/llvm-project/pull/157, https://github.com/anza-xyz/llvm-project/pull/156, and https://github.com/anza-xyz/llvm-project/pull/155.
2. Update the linker script.
3. Remove SBPFv3 from CI, since successful tests require an sbpf release and a valid Agave commit with it.
4. Bump dependencies version for release.