### PR TITLE
[SOL] Simplify linker script for SBPFv3

### DIFF
--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -54,7 +54,6 @@ SECTIONS
         _heap_end = .;
         . = ALIGN(8);
    } :heap
-   .strtab : { *(.strtab) } :other
   /DISCARD/ : {
       *(.comment*)
       *(.eh_frame*)
@@ -73,7 +72,6 @@ PHDRS
   rodata PT_LOAD FLAGS(4);
   stack PT_LOAD FLAGS(6);
   heap PT_LOAD FLAGS(6);
-  other PT_NULL FLAGS(0);
 }
 ";
 


### PR DESCRIPTION
Leaving only a strict specification for `.strtab` adds padding to the last section, bloating large contracts (around 200kb) by 50kb.