### PR TITLE
[SOL] Revamp CI

### DIFF
--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
+    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
+    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
+    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
+    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev c5df324a62a5e03d2ff5f9efbdbf5a4e4182325e \
+    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -106,9 +106,6 @@ pr:
   - image: x86_64-gnu-tools
     continue_on_error: true
     <<: *job-linux-4c
-  - image: sbf-solana-solana
-    continue_on_error: true
-    <<: *job-linux-4c
   - image: sbpf-solana-solana
     continue_on_error: true
     <<: *job-linux-4c
@@ -118,9 +115,9 @@ pr:
   - image: sbpfv2-solana-solana
     continue_on_error: true
     <<: *job-linux-4c
-#  - image: sbpfv3-solana-solana
-#    continue_on_error: true
-#    <<: *job-linux-4c
+  - image: sbpfv3-solana-solana
+    continue_on_error: true
+    <<: *job-linux-4c
 
 # Jobs that run when you perform a try build (@bors try)
 # These jobs automatically inherit envs.try, to avoid repeating


### PR DESCRIPTION
After we redesigned SBPFv3 and the new SBPF version was released, I updated `cargo-run-solana-tests` and now we can run CI for SBPFv3 again for the compiler related repositories.