### PR TITLE
[SOL] Bump version for v1.51 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "rustc-build-sysroot"
 version = "0.5.3"
-source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.50#932133f4069426f6b394a82c011c9fdf08b300ff"
+source = "git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.51#34e8960e38904f424f410d4673a0b669af75ef4e"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 core = { path = "./sysroot_src/library/core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }
 alloc = { path = "./sysroot_src/library/alloc" }
 std = { path = "./sysroot_src/library/std", features = ["panic_unwind", "backtrace"] }
 test = { path = "./sysroot_src/library/test" }

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 [[package]]
 name = "compiler_builtins"
 version = "0.1.138"
-source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.50#759adff89713678bfd9c7630fe0f60088f635085"
+source = "git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.51#70588e8fc636c3456c4b1317a1f04a93d14a910f"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -45,4 +45,4 @@ rustc-demangle.debug = 0
 rustc-std-workspace-core = { path = 'rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'rustc-std-workspace-std' }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50", features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 alloc = { path = "../alloc" }
 core = { path = "../core" }
 unwind = { path = "../unwind" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -10,7 +10,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50", features = ['rustc-dep-of-std'] }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
 # FIXME: Pinned due to build error when bumped (#132556)

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.50" }
+compiler_builtins = { git = "https://github.com/anza-xyz/compiler-builtins", tag = "solana-tools-v1.51" }
 cfg-if = "1.0"
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]

--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
+    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
+    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
+    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
+    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev 2ff58e81919c5c6580620f4b1f0e37777ef6787f \
+    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/tools/miri/cargo-miri/Cargo.toml
+++ b/src/tools/miri/cargo-miri/Cargo.toml
@@ -18,7 +18,7 @@ directories = "5"
 rustc_version = "0.4"
 serde_json = "1.0.40"
 cargo_metadata = "0.18.0"
-rustc-build-sysroot = { git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.50"  }
+rustc-build-sysroot = { git = "https://github.com/anza-xyz/rustc-build-sysroot", tag = "solana-tools-v1.51"  }
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -8,8 +8,8 @@ const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
     r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
-    r#""git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.50#759adff89713678bfd9c7630fe0f60088f635085""#,
-    r#""git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.50#932133f4069426f6b394a82c011c9fdf08b300ff""#
+    r#""git+https://github.com/anza-xyz/compiler-builtins?tag=solana-tools-v1.51#70588e8fc636c3456c4b1317a1f04a93d14a910f""#,
+    r#""git+https://github.com/anza-xyz/rustc-build-sysroot?tag=solana-tools-v1.51#34e8960e38904f424f410d4673a0b669af75ef4e""#
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
There have been multiple improvements to LLVM code generation since the last release. It is time to bring them to users before we start the Rust 1.89 upgrade.

Rust 1.89 will be stable on August 7, by which time we can start the update.