### PR TITLE
build: Add `--nix` flag to build rust in nix-shell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,9 +20,6 @@ case "$1" in
     --help)
         echo "--llvm to rebuild llvm, --nix to use nix";
         exit;
-    -h)
-        echo "--llvm to rebuild llvm, --nix to use nix";
-        exit;
 esac
 
 unameOut="$(uname -s)-$(uname -m)"
@@ -39,8 +36,8 @@ if [ -n "${REBUILD_LLVM}" ]; then
     rm -f build/${HOST_TRIPLE}/llvm/llvm-finished-building;
 fi
 
-if [ -n "${USE_NIX}" ]; then
-    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana"
+if [ -n "${WITH_NIX}" ]; then
+    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana"
 else
-    ./x.py build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana
+    ./x.py build --stage 1 --target sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana
 fi

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,24 @@
 
 set -ex
 
-if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
-    echo "--llvm to rebuild llvm";
-    exit;
-fi
+WITH_NIX=
+REBUILD_LLVM=
+case "$1" in
+    --nix)
+        WITH_NIX=1
+        shift
+        ;;
+    --llvm)
+        REBUILD_LLVM=1
+        shift
+        ;;
+    --help)
+        echo "--llvm to rebuild llvm, --nix to use nix";
+        exit;
+    -h)
+        echo "--llvm to rebuild llvm, --nix to use nix";
+        exit;
+esac
 
 unameOut="$(uname -s)-$(uname -m)"
 case "${unameOut}" in
@@ -21,7 +35,12 @@ case "${unameOut}" in
     *)              HOST_TRIPLE=x86_64-unknown-linux-gnu
 esac
 
-if [ "$1" == "--llvm" ]; then
+if [ -n "${REBUILD_LLVM}" ]; then
     rm -f build/${HOST_TRIPLE}/llvm/llvm-finished-building;
 fi
-./x.py build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana
+
+if [ -n "${USE_NIX}" ]; then
+    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana"
+else
+    ./x.py build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana
+fi


### PR DESCRIPTION
#### Problem

More information at https://github.com/anza-xyz/platform-tools/pull/109, but Rust is currently built with a few additional shared libraries.

#### Summary of changes

Add a `--nix` flag to build.sh to optionally build with nix-shell.