### PR TITLE
[SOL] Optimize libraries for speed

### DIFF
--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -273,7 +273,7 @@ prefix = "opt/sbf-rust"
 # Note: the slowness of the non optimized compiler compiling itself usually
 #       outweighs the time gains in not doing optimizations, therefore a
 #       full bootstrap takes much more time with `optimize` set to false.
-optimize = "s"
+optimize = 3
 
 # Indicates that the build should be configured for debugging Rust. A
 # `debug`-enabled compiler and standard library will be somewhat


### PR DESCRIPTION
**Problem**

I had used `s` in the past to optimize the compiler libraries, because it affected the size of SBFPv2 programs. That setting impacts CU consumption. Since we'll abandon SBPFv2 and we've learnt that less CUs are more important than program size, I'm switching back to `3`.

See the benchmark of Solana-program, compared to master:

| Name | CUs | Delta |
|------|------|-------|
| Account (0) | 106 | -9 |
| Account (1) | 305 | -9 |
| Account (2) | 471 | -9 |
| Account (3) | 637 | -9 |
| Account (4) | 803 | -9 |
| Account (5) | 969 | -9 |
| Account (6) | 1135 | -9 |
| Account (7) | 1301 | -9 |
| Account (8) | 1467 | -9 |
| Account (16) | 2795 | -9 |
| Account (32) | 5451 | -9 |
| Account (64) | 10763 | -9 |

**Solution**

Use all optimizations:

https://github.com/anza-xyz/rust/blob/ff75d518699af2c749f9dc363b1508f9c9147ada/bootstrap.example.toml#L511-L520