### PR TITLE
[SOL] Prepare 1.89 release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ if [ -n "${REBUILD_LLVM}" ]; then
 fi
 
 if [ -n "${WITH_NIX}" ]; then
-    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana"
+    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana"
 else
-    ./x.py build --stage 1 --target sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana,sbpfv4-solana-solana
+    ./x.py build --stage 1 --target "${HOST_TRIPLE}",sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana
 fi


### PR DESCRIPTION
This PR brings LLVM commit https://github.com/anza-xyz/llvm-project/pull/169 so that we can build the release tarball for MacOS in CI.

It updates the build script, putting back the host triple, since we found out that some crates still need it, and removes sbpfv3 and v4. v3 and v4 aren't yet ready for shipment. I'll remove them from the release tarball, so that we can decrease its size.