### PR TITLE
[SOL] Prepare sbpfv3 release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ if [ -n "${REBUILD_LLVM}" ]; then
 fi
 
 if [ -n "${WITH_NIX}" ]; then
-    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana"
+    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana"
 else
-    ./x.py build --stage 1 --target "${HOST_TRIPLE}",sbf-solana-solana,sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana
+    ./x.py build --stage 1 --target "${HOST_TRIPLE}",sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana
 fi

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -478,9 +478,6 @@ impl<'a> GccLinker<'a> {
                     .unwrap_or(self.sess.target.cpu.as_ref().to_string());
                 if cpu_type == "v3" || cpu_type == "v4" {
                     self.link_arg("-Bsymbolic");
-                    if self.sess.opts.debuginfo == DebugInfo::None {
-                        self.link_arg("--strip-all");
-                    }
                 }
             }
         }

--- a/compiler/rustc_target/src/spec/base/sbf_base.rs
+++ b/compiler/rustc_target/src/spec/base/sbf_base.rs
@@ -31,29 +31,15 @@ SECTIONS
 const V3_LINKER_SCRIPT: &str = r"
 SECTIONS
 {
-  .text 0x000000000 : {
-    . = 0x00;
-    KEEP(*(.text.abort))
-     *(.text*)
-  } :text
-  .rodata 0x100000000 : {
+  .rodata 0x000000000 : SUBALIGN(8) {
+    BYTE(0);
     *(.rodata*)
     *(.data.rel.ro*)
-    BYTE(0);
     . = ALIGN(8);
   } :rodata
-  .bss.stack 0x200000000 (NOLOAD) : {
-      _stack_start = .;
-      . = . + 0x1000;
-      _stack_end = .;
-      . = ALIGN(8);
-   } :stack
-  .bss.heap 0x300000000 (NOLOAD) : {
-        _heap_start = .;
-        . = . + 0x1000;
-        _heap_end = .;
-        . = ALIGN(8);
-   } :heap
+  .text 0x100000000 : {
+     *(.text*)
+  } :text
   /DISCARD/ : {
       *(.comment*)
       *(.eh_frame*)
@@ -66,13 +52,14 @@ SECTIONS
       *(.dynstr)
     }
 }
+
 PHDRS
 {
-  text PT_LOAD FLAGS(1);
   rodata PT_LOAD FLAGS(4);
-  stack PT_LOAD FLAGS(6);
-  heap PT_LOAD FLAGS(6);
+  text PT_LOAD FLAGS(1);
+  other PT_NULL FLAGS(0);
 }
+
 ";
 
 pub(crate) fn opts(version: &'static str) -> TargetOptions {
@@ -102,7 +89,6 @@ pub(crate) fn opts(version: &'static str) -> TargetOptions {
     let features = match version {
         "v4" => "+static-syscalls,+abi-v2",
         "v3" => "+static-syscalls",
-        "v0" => "+store-imm,+jmp-ext",
         _ => ""
     };
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3501,7 +3501,10 @@ impl Target {
             "loongarch64" => (Architecture::LoongArch64, None),
             "csky" => (Architecture::Csky, None),
             "arm64ec" => (Architecture::Aarch64, Some(object::SubArchitecture::Arm64EC)),
-            "sbf" => (Architecture::Sbf, None),
+            "sbf" if self.options.cpu.as_ref() != "v3"
+                && self.options.cpu.as_ref() != "v4"  => (Architecture::Sbf, None),
+            "sbf" if self.options.cpu.as_ref() == "v3"
+                || self.options.cpu.as_ref() == "v4"  => (Architecture::Bpf, None),
             // Unsupported architecture.
             _ => return None,
         })

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -650,7 +650,7 @@ const BPF_FEATURES: &[(&str, Stability, ImpliedFeatures)] =
     &[("alu32", Unstable(sym::bpf_target_feature), &[])];
 
 const SBF_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
-    ("alu32", Unstable(sym::sbf_target_feature), &[]),
+    ("alu32", Stable, &[]),
     ("static-syscalls", Stable, &[]),
     ("dynamic-frames", Stable, &[]),
     ("abi-v2", Stable, &[]),

--- a/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
+    --rev db104fd1ce22986a0935f10f07e7e1f889db7e80 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpf-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
+    --rev db104fd1ce22986a0935f10f07e7e1f889db7e80 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/
@@ -38,8 +38,8 @@ ENV RUST_CONFIGURE_ARGS \
     --set llvm.clang
 
 ENV SCRIPT CARGO_TARGET_SBPF_SOLANA_SOLANA_RUNNER=\"cargo-run-solana-tests --heap-size 204857600\" \
-    CARGO_TARGET_SBPFV0_SOLANA_SOLANA_RUNNER=\"cargo-run-solana-tests --heap-size 204857600\" \
+    CARGO_TARGET_SBF_SOLANA_SOLANA_RUNNER=\"cargo-run-solana-tests --heap-size 204857600\" \
     LLVM_HOME=/checkout/obj/build/x86_64-unknown-linux-gnu/llvm \
     PATH="${HOME}/.cargo/bin:${PATH}" \
-    python3 /checkout/x.py --stage 1 test --host='' --target sbpf-solana-solana,sbpfv0-solana-solana \
+    python3 /checkout/x.py --stage 1 test --host='' --target sbpf-solana-solana,sbf-solana-solana \
     library/core

--- a/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv1-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
+    --rev db104fd1ce22986a0935f10f07e7e1f889db7e80 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv2-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
+    --rev db104fd1ce22986a0935f10f07e7e1f889db7e80 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
+++ b/src/ci/docker/host-x86_64/sbpfv3-solana-solana/Dockerfile
@@ -23,7 +23,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN PATH="${HOME}/.cargo/bin:${PATH}" \
     cargo install --git https://github.com/anza-xyz/cargo-run-solana-tests.git \
-    --rev ccfb0a3f5f967f3cf52fef0c95e283c7cab1836e \
+    --rev db104fd1ce22986a0935f10f07e7e1f889db7e80 \
     --bin cargo-run-solana-tests --root /usr/local
 
 COPY scripts/sccache.sh /scripts/


### PR DESCRIPTION
**Problem**

We are releasing sbpfv3 with a new ELF configuration and with eBPF compatibility, but the compiler does not have this version yet.

**Summary of changes**

1. Modify linker script to work with the new ELF layout.
2. Remove `--strip-all` from the linker argument, since this is a remnant of when we v3 had symbol tables.
3. Make `alu32` stable, as it now works with sbpfv3.
4. Bump LLVM commit.
5. Revamp CI.
6. Remove `sbf-solana-solana` from the build script, since we are not using it anymore, and add `sbpfv3-solana-solana`.