### PR TITLE
nix-shell: Fix build for all platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ if [ -n "${REBUILD_LLVM}" ]; then
 fi
 
 if [ -n "${WITH_NIX}" ]; then
-    nix-shell src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana"
+    nix-shell ./src/tools/nix-dev-shell/shell.nix --pure --run "x build --stage 1 --target ${HOST_TRIPLE},sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana"
 else
     ./x.py build --stage 1 --target "${HOST_TRIPLE}",sbpf-solana-solana,sbpfv1-solana-solana,sbpfv2-solana-solana,sbpfv3-solana-solana
 fi

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -35,9 +35,11 @@ stdenv.mkDerivation (self: {
     rustc
     makeBinaryWrapper
   ]
-  # Provides the mig command
-  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.bootstrap_cmds;
-
+  # Provides the codesign and mig commands
+  ++ lib.optional stdenv.hostPlatform.isDarwin [
+    darwin.bootstrap_cmds
+    darwin.sigtool
+  ];
 
   env.PYTHON = python3.interpreter;
   buildPhase = ''

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -18,6 +18,7 @@
   ninja,
   cmake,
   glibc,
+  swig,
 }:
 stdenv.mkDerivation (self: {
   strictDeps = true;
@@ -69,6 +70,7 @@ stdenv.mkDerivation (self: {
         pkg-config
         cmake
         ninja
+        swig
         stdenv.cc
       ];
       ldLib = [

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -13,6 +13,7 @@
   patchelf,
   cacert,
   zlib,
+  darwin,
   # LLVM Deps
   ninja,
   cmake,
@@ -33,7 +34,10 @@ stdenv.mkDerivation (self: {
   nativeBuildInputs = [
     rustc
     makeBinaryWrapper
-  ];
+  ]
+  # Provides the mig command
+  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.bootstrap_cmds;
+
 
   env.PYTHON = python3.interpreter;
   buildPhase = ''


### PR DESCRIPTION
#### Problem

The `--nix` flag in `build.sh` doesn't work for all platforms.

* The mac build fails due to `mig` and `codesign` missing
* The python bindings aren't generated because `swig` isn't present in the build environment

#### Summary of changes

* Add bootstramp_cmds and sigtool to mac build
* Add swig to all builds