### PR TITLE
[SOL] Include git hash in compiler version string

### DIFF
--- a/bootstrap.toml
+++ b/bootstrap.toml
@@ -397,6 +397,9 @@ debug-assertions = false
 # rustc to execute.
 lld = true
 
+# Include the git hash in the version
+omit-git-hash = false
+
 # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
 # sysroot.
 #llvm-tools = false


### PR DESCRIPTION
**The problem**  

Without this, DWARF debug info shows a generic version like:
DW_AT_producer ("clang LLVM (rustc version 1.89.0-dev)")

This makes it impossible to distinguish between different builds of the same Rust version. With the git hash included, the version becomes identifiable (e.g., rustc 1.89.0-dev (daa3af4a1 2026-03-03)), which is important when multiple platform tools may reference the same Rust version but are actually built from different commits.

**What's changed**

Just one change in bootstrap.toml: added omit-git-hash = false under the [rust] section to include the git hash in the compiler version string.